### PR TITLE
Add PFT foundation files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Working files
+scratch/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,142 @@
+# CLAUDE.md - LLM Integration Guide
+
+## Project Overview
+
+**BEACON** (Blueprint Engineering And Component Organizational Nexus) is the CAD and 3D model repository for the O.A.S.I.S. wearable computing platform. It contains printable components, mechanical designs, and assembly references for building O.A.S.I.S. hardware.
+
+---
+
+## Repository Structure
+
+```
+beacon/
+├── hud/                          # HUD display mounting components
+│   ├── HorizonHUD-MK3.17_*.stl   # 3D printable HUD parts
+│   └── *.png                     # Reference images
+├── wearable_systems/             # Body-worn component housings
+│   ├── Jetson_Sling_*.stl        # Jetson carrier/sling parts
+│   └── *.png                     # Reference images
+├── speakers/                     # Audio component mounts
+├── remote_control/               # Remote/controller housings
+├── misc_mechanical_components/   # General purpose parts
+│   ├── headphone clamp *.stl     # Audio mounting
+│   └── mic clamp *.stl           # Microphone mounting
+├── CLAUDE.md                     # This file
+├── CONTRIBUTING.md               # Contribution guidelines
+├── LICENSE                       # GPLv3
+└── README.md                     # Project overview
+```
+
+---
+
+## File Formats
+
+| Format | Purpose | Software |
+|--------|---------|----------|
+| `.stl` | 3D printing | Any slicer (Cura, PrusaSlicer, etc.) |
+| `.step` | CAD interchange | FreeCAD, Fusion 360, SolidWorks |
+| `.f3d` | Fusion 360 native | Autodesk Fusion 360 |
+| `.FCStd` | FreeCAD native | FreeCAD |
+| `.png` | Reference images | Any image viewer |
+
+---
+
+## Design Guidelines
+
+### Printing Considerations
+
+- **Layer height**: Most parts designed for 0.2mm layer height
+- **Infill**: 15-20% typical, 40%+ for structural parts
+- **Material**: PLA suitable for most parts, PETG for heat exposure
+- **Supports**: Check part orientation; many designed to print without supports
+
+### Naming Convention
+
+```
+[Component]-[Version]_[Variant].[ext]
+
+Examples:
+- HorizonHUD-MK3.17_v7_p1.stl      # HUD part 1, version 7
+- Jetson_Sling_Base_v2.stl         # Sling base, version 2
+- headphone clamp bottom v3.stl    # Headphone clamp, version 3
+```
+
+---
+
+## Component Categories
+
+### HUD (hud/)
+
+Mounting system for the heads-up display:
+- Multi-part assembly for display positioning
+- Camera buck variants (large/tight fit)
+- Designed for specific display modules
+
+### Wearable Systems (wearable_systems/)
+
+Body-worn component housings:
+- Jetson Sling: Multi-part enclosure (Base, Lid, Lens)
+- See reference images for assembly
+
+### Audio Components (speakers/, misc_mechanical_components/)
+
+Mounting solutions for audio hardware:
+- Headphone clamps
+- Microphone mounts
+- Speaker housings
+
+---
+
+## Working with This Repository
+
+### For 3D Printing
+
+1. Download the `.stl` files for your component
+2. Import into your slicer software
+3. Orient for optimal printing (check reference images)
+4. Slice with appropriate settings for your printer
+5. Print and assemble
+
+### For Design Modifications
+
+1. Use `.step` files for CAD interchange
+2. Or native format files (`.f3d`, `.FCStd`) if available
+3. Maintain version numbering in filenames
+4. Export both native format and `.stl` for printing
+
+### Common Tasks
+
+| Task | Approach |
+|------|----------|
+| Print a component | Download STL, slice, print |
+| Modify a design | Import STEP into CAD, modify, export new version |
+| Add new component | Create in CAD, export STL + STEP, add reference image |
+| Fix print issues | Adjust orientation, supports, or modify design |
+
+---
+
+## Integration Points
+
+### O.A.S.I.S. Ecosystem
+
+| Component | Relationship |
+|-----------|--------------|
+| **MIRAGE** | HUD mounts house the display hardware |
+| **AURA** | Sensor housings for helmet electronics |
+| **SPARK** | Gauntlet/hand component housings |
+
+### S.C.O.P.E. Coordination
+
+- **Meta-repo**: [malcolmhoward/the-oasis-project-meta-repo](https://github.com/malcolmhoward/the-oasis-project-meta-repo)
+- **Documentation**: Aggregated in S.C.O.P.E. coordination docs
+
+---
+
+## License
+
+BEACON is licensed under **GPLv3**. See LICENSE for details.
+
+This means you can:
+- Use, modify, and distribute the designs
+- Must share modifications under the same license
+- Must provide attribution

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,3 +140,31 @@ This means you can:
 - Use, modify, and distribute the designs
 - Must share modifications under the same license
 - Must provide attribution
+
+## Branch Naming Convention
+
+**Critical**: Branch names must include the GitHub issue number being addressed.
+
+### Format
+```
+feat/<component>/<issue#>-<short-description>
+```
+
+### Before Creating a Branch
+
+1. **Identify the issue** you're working on (check GitHub Issues)
+2. **Use that issue's number** in the branch name
+3. **Verify** the issue number matches the work being done
+
+### Examples
+```bash
+# Check available issues first
+gh issue list --repo malcolmhoward/beacon
+
+# Create branch with correct issue number
+git checkout -b feat/beacon/<issue#>-description
+```
+
+### Common Mistake
+❌ Using arbitrary numbers or the wrong issue number
+✅ Always check `gh issue list` or GitHub Issues before creating a branch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,8 +35,22 @@ git remote add upstream https://github.com/The-OASIS-Project/beacon.git
 
 ### Step 3: Create a Feature Branch
 
+**Never work directly on `main`**. Always create a branch.
+
+**First, verify the correct issue number:**
+
 ```bash
-git checkout -b type/description
+# List open issues to find the right issue number
+gh issue list --repo malcolmhoward/beacon
+```
+
+**Then create your branch with that issue number:**
+
+```bash
+git checkout -b feat/beacon/<issue#>-description
+
+# Example: Working on issue #2
+git checkout -b feat/beacon/2-foundation-files
 ```
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,175 @@
+# Contributing to BEACON
+
+Thank you for your interest in contributing to BEACON!
+
+This guide explains how to contribute CAD designs and 3D models to the project.
+
+---
+
+## Before You Start
+
+### Understanding Our Workflow
+
+We use a **fork-first workflow**. This means:
+- You work on your own copy (fork) of the repository
+- Changes are proposed via Pull Requests from your fork
+- This keeps the main repository clean and organized
+
+---
+
+## Fork-First Workflow
+
+### Step 1: Fork the Repository
+
+1. Click the "Fork" button on the repository page
+2. This creates your personal copy at `github.com/YOUR-USERNAME/beacon`
+
+### Step 2: Clone Your Fork
+
+```bash
+git clone https://github.com/YOUR-USERNAME/beacon.git
+cd beacon
+
+git remote add upstream https://github.com/The-OASIS-Project/beacon.git
+```
+
+### Step 3: Create a Feature Branch
+
+```bash
+git checkout -b type/description
+```
+
+---
+
+## File Guidelines
+
+### Required Formats
+
+| Type | Required | Optional |
+|------|----------|----------|
+| 3D Printable | `.stl` | `.3mf` |
+| CAD Source | `.step` | Native format (`.f3d`, `.FCStd`) |
+| Reference | `.png` | `.jpg` |
+
+### Naming Convention
+
+```
+[Component]-[Version]_[Variant].[ext]
+
+Examples:
+- HorizonHUD-MK3.17_v7_p1.stl
+- Jetson_Sling_Base_v2.stl
+- headphone clamp bottom v3.stl
+```
+
+### Version Numbering
+
+- Increment version number for design changes
+- Use `_p1`, `_p2`, etc. for multi-part assemblies
+- Use descriptive variants: `_large`, `_tight`, `_slim`
+
+---
+
+## Design Standards
+
+### Print Considerations
+
+- Design for 0.2mm layer height unless noted
+- Minimize support requirements where possible
+- Consider print orientation in design
+- Test fit with mating components
+
+### File Quality
+
+- Manifold/watertight STL meshes
+- Reasonable polygon count (not excessively high)
+- Correct scale (millimeters)
+- Proper orientation (Z-up)
+
+### Documentation
+
+For new components, include:
+- Reference image showing the part
+- Brief description in PR
+- Print settings if non-standard
+- Assembly notes if multi-part
+
+---
+
+## Contribution Types
+
+### New Components
+
+1. Create design in your CAD software
+2. Export `.stl` (for printing) and `.step` (for editing)
+3. Add reference image
+4. Place in appropriate directory
+5. Submit PR with description
+
+### Design Improvements
+
+1. Import existing `.step` file
+2. Make modifications
+3. Increment version number
+4. Export new files
+5. Submit PR explaining changes
+
+### Bug Fixes
+
+Common issues to fix:
+- Non-manifold geometry
+- Incorrect dimensions
+- Print failures
+- Fit issues with other components
+
+---
+
+## Pull Request Process
+
+### Before Submitting
+
+- [ ] Files follow naming convention
+- [ ] STL is manifold/watertight
+- [ ] STEP file included for editable source
+- [ ] Reference image provided (for new parts)
+- [ ] Tested print (if possible)
+
+### PR Description Template
+
+```markdown
+## Summary
+Brief description of the component or change.
+
+## Type of Change
+- [ ] New component
+- [ ] Design improvement
+- [ ] Bug fix (geometry issues)
+- [ ] Documentation
+
+## Files Added/Changed
+List of files
+
+## Print Settings (if applicable)
+- Layer height:
+- Infill:
+- Supports:
+- Material:
+
+## Testing
+How was this tested? (printed, fit-checked, etc.)
+```
+
+---
+
+## Code of Conduct
+
+We are committed to providing a welcoming and inclusive environment.
+Please be respectful and constructive in all interactions.
+
+---
+
+## Getting Help
+
+- **Questions**: Open a GitHub Discussion or Issue
+- **Design Issues**: Open an issue describing the problem
+- **O.A.S.I.S. Ecosystem**: See [S.C.O.P.E.](https://github.com/malcolmhoward/the-oasis-project-meta-repo) for cross-project coordination

--- a/README.md
+++ b/README.md
@@ -1,2 +1,82 @@
-# beacon
-Blueprint Engineering And Component Organizational Nexus (CAD Files)
+# BEACON
+
+**Blueprint Engineering And Component Organizational Nexus** - CAD files and 3D printable components for the O.A.S.I.S. wearable computing platform.
+
+## Overview
+
+BEACON contains 3D models, mechanical designs, and printable components for building O.A.S.I.S. hardware. Files are provided in standard formats compatible with common 3D printing and CAD software.
+
+## Repository Structure
+
+```
+beacon/
+├── hud/                          # HUD display mounting components
+├── wearable_systems/             # Body-worn component housings
+├── speakers/                     # Audio component mounts
+├── remote_control/               # Remote/controller housings
+└── misc_mechanical_components/   # General purpose parts
+```
+
+## File Formats
+
+| Format | Purpose | Software |
+|--------|---------|----------|
+| `.stl` | 3D printing | Any slicer (Cura, PrusaSlicer, etc.) |
+| `.step` | CAD interchange | FreeCAD, Fusion 360, SolidWorks |
+| `.png` | Reference images | Any image viewer |
+
+## Quick Start
+
+### 3D Printing
+
+1. Download the `.stl` files for your component
+2. Import into your slicer software
+3. Check reference images (`.png`) for orientation
+4. Slice with appropriate settings:
+   - Layer height: 0.2mm typical
+   - Infill: 15-20% (40%+ for structural parts)
+   - Material: PLA or PETG
+5. Print and assemble
+
+### Design Modifications
+
+1. Import `.step` files into your CAD software
+2. Make modifications
+3. Export new `.stl` for printing
+4. Maintain version numbering in filenames
+
+## Components
+
+### HUD (hud/)
+
+HorizonHUD mounting system - multi-part assembly for display positioning.
+
+### Wearable Systems (wearable_systems/)
+
+Body-worn housings including Jetson Sling enclosure.
+
+### Audio (speakers/, misc_mechanical_components/)
+
+Mounting solutions for headphones, microphones, and speakers.
+
+## Related Projects
+
+BEACON is part of the [O.A.S.I.S. Project](https://github.com/The-OASIS-Project):
+
+| Component | Purpose |
+|-----------|---------|
+| [MIRAGE](https://github.com/The-OASIS-Project/mirage) | HUD display system |
+| [DAWN](https://github.com/The-OASIS-Project/dawn) | AI voice assistant |
+| [SPARK](https://github.com/The-OASIS-Project/spark) | Hand/gauntlet firmware |
+| [AURA](https://github.com/The-OASIS-Project/aura) | Helmet sensor firmware |
+| [GENESIS](https://github.com/The-OASIS-Project/genesis) | Python utilities |
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+
+## License
+
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or any later version.
+
+See [LICENSE](LICENSE) for full details.

--- a/docs/parts-catalog.md
+++ b/docs/parts-catalog.md
@@ -1,0 +1,27 @@
+# B.E.A.C.O.N. - Blueprint Engineering And Component Organizational Nexus (CAD Files)
+
+## Parts Catalog
+
+### HUD Mounting
+
+<img src="https://www.oasisproject.net/assets/Horizon HUD v7 - back.png" alt="MIRAGE HUD Back" width="600">
+
+<img src="https://www.oasisproject.net/assets/Horizon HUD v7 - front.png" alt="MIRAGE HUD Front" width="600">
+
+### Misc. Mechanical Parts
+
+<img src="https://www.oasisproject.net/assets/Audio Tie Downs v3.png" alt="Audio Tie-downs for helmet" width="600">
+
+<img src="https://www.oasisproject.net/assets/Misc. Parts v2.png" alt="Misc. Parts" width="600">
+
+### Remote Control
+
+<img src="https://www.oasisproject.net/assets/Pad5+Case v13.png" alt="Stark Industries Case for Pad 5" width="600">
+
+### Speakers
+
+<img src="https://www.oasisproject.net/assets/Speaker Chassis v6.png" alt="Wearable Speaker" width="600">
+
+### Wearable Systems
+
+<img src="https://www.oasisproject.net/assets/Jetson Prototype Sling v2.png" alt="Jetson Sling" width="600">


### PR DESCRIPTION
## Summary
- Add governance foundation files generated with PFT v3.7.0 (minimal preset)
- Files: README.md updates, CONTRIBUTING.md, CLAUDE.md, LICENSE

Tracked by: malcolmhoward/the-oasis-project-meta-repo#22

## Test plan
- [ ] Verify generated files are customized (no [REPLACE:] placeholders)
- [ ] Verify LICENSE is appropriate
- [ ] Verify CLAUDE.md has component-specific context

🤖 Generated with [Claude Code](https://claude.com/claude-code)